### PR TITLE
upgrade to alpine 3.15 to fix blackduck vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /src
 COPY . .
 RUN go run build.go
 
-FROM alpine:3.14.2
+FROM alpine:3.15
 WORKDIR /app
 COPY --from=builder /src/restic /bin/restic
 ENTRYPOINT ["restic"]


### PR DESCRIPTION
There's a vulnerability with `busybox 1.33.1`, which is what `alpine 3.14.x` uses. This PR upgrades to `alpine 3.15`, which uses `busybox 1.34.1`, which is the recommended version (see https://jira.ngage.netapp.com/browse/ASTRACTL-13294):

```
--> docker run -it --tty --rm alpine:3.15
/ # busybox
BusyBox v1.34.1 (2021-11-23 00:57:35 UTC) multi-call binary.
BusyBox is copyrighted by many authors between 1998-2015.
Licensed under GPLv2. See source distribution for detailed
copyright notices.
```